### PR TITLE
Make Markdown-style applicable again.

### DIFF
--- a/styles/syntax/markdown.less
+++ b/styles/syntax/markdown.less
@@ -1,4 +1,4 @@
-.syntax--gfm {
+.syntax--markup, .syntax--md, .syntax--gfm, .syntax--pfm {
   .syntax--link .syntax--entity {
     color: @violet;
   }


### PR DESCRIPTION
### Description of the Change

The Markdown-styles weren't applied [anymore]. This change makes the style work again.

### Benefits

This change makes the style work again.

### Possible Drawbacks

None, as far as I can tell.

### Applicable Issues

None, as far as I can tell.
